### PR TITLE
minimal updates to get working end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore the certs we generate
+certs/

--- a/nomad/nomad-agent-config.hcl
+++ b/nomad/nomad-agent-config.hcl
@@ -16,9 +16,7 @@ plugin "docker" {
 consul {
   ssl       = true
 
-  # set as environment variable CONSUL_HTTP_ADDR
   address = "<Consul ip address>:8501" # private address of the instance running Consul
-  # set as environment variable CONSUL_GRPC_ADDR
   grpc_address = "<Consul ip address>:8503"
 
   # these are certs that consul-nomad use to establish TLS/mTLS
@@ -28,7 +26,7 @@ consul {
   key_file = "certs/consul/dc1-server-consul-0-key.pem"
 
   # input the nomad server token.
-  token = "<token created in Consul for Nomad ACL>"
+  token = "<token created in Consul for Nomad agent>"
 }
 
 # Enable the server
@@ -46,8 +44,8 @@ tls {
 
   # These are certs that Nomad uses to interact with Nomad over TLS/mTLS
   ca_file   = "certs/nomad/nomad-agent-ca.pem"
-  cert_file = "certs/nomad/global-client-nomad.pem"
-  key_file  = "certs/nomad/global-client-nomad-key.pem"
+  cert_file = "certs/nomad/global-server-nomad.pem"
+  key_file  = "certs/nomad/global-server-nomad-key.pem"
 
   verify_server_hostname = true
   verify_https_client    = true


### PR DESCRIPTION
After testing in a fresh environment, I found a number of steps that don't work, are out of order, or have undesireable effects. This changeset represents a minimum amount of updates just to get this all working without improving the workflow more generally.

This includes:
* Bootstrap Consul ACLs after configuring the Consul environment variables, so that we can connect to the Consul agent we're trying to configure.
* Run `nomad` with the `-dev-connect` flag so that the API GW is listening on a non-localhost address.
* Make it clear the certs used for the Nomad CLI are the ones named "server".
* Update the Docker build step so that in the default local development case we're building an image that Nomad will not try to download.
* Add the missing Consul gRPC and HTTP address to the values we write to Nomad Variables, and make the name of the Consul CA variable consistent with Consul's use.
* Explain where to find the API GW address and port.
* Remove incorrect references to env vars from the Nomad agent config.
* Make the `tls.cert_file` and `tls.key_file` path match the names of the files we create.
* Ensure we don't commit certificates by adding them to `.gitignore`

Additional PRs will follow on this repo to deal with #2 and #3.