### PR TITLE
Update namespace variable for API GW deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ the `-var` option to the `nomad job run` command. For example:
 nomad job run \
     -var="consul_image=hashicorp/consul:1.18.1" \
     -var="envoy_image=hashicorp/envoy:1.28.1" \
-    -var="namespace=consul" \
+    -var="namespace=ingress" \
     ./api-gateway.nomad.hcl
 ```
 


### PR DESCRIPTION
It looks like `consul` was used instead of `ingress` for the namespace. I don't know if that was on purpose. Ideally it would be nice to use the `consul` namespace on all commands, but since 'ingress` is already used for ACL set up and other commands, this makes it more consistent. 