### PR TITLE
Fixes ACL Policy and adds Service Defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ policy. Note that the name of the role must match the binding rule
 Nomad Workload Identity with Consul, when used with the `ingress` namespace you
 just created.
 
+>NOTE: Update the service name inside the `api-gateway.policy.hcl` if you intend to change the api-gateway service name by overriding `var.api_gateway_name` below.
+
 ```
 consul acl policy create -name "api-gateways" \
     -description "api gateway policy" \
@@ -248,16 +250,18 @@ Gateway registered.
 This section will run an example upstream application `hello` and configure
 access to it from the API Gateway.
 
-1. Add intentions to allow traffic from the API Gateway to `hello` by running
+1. Configure Service Defaults to set the `hello-app` service type as `http` by running `consul config write example/hello-app-service-defaults.hcl`
+
+2. Add intentions to allow traffic from the API Gateway to `hello` by running
    `consul config write example/hello-app-intentions.hcl`
 
-2. Register a listener for the API Gateway by running `consul config write
+3. Register a listener for the API Gateway by running `consul config write
    example/gateway-listeners.hcl`
 
-3. Register http routes for the API Gateway so that Envoy knows how and where to
+4. Register http routes for the API Gateway so that Envoy knows how and where to
    write the traffic by running `consul config write example/my-http-route.hcl`
 
-4. Start the `hello` app by running `nomad run example/hello-app.nomad.hcl`
+5. Start the `hello` app by running `nomad run example/hello-app.nomad.hcl`
 
 Once the deployment is complete, you can test the API Gateway.
 - Run `nomad job status -namespace ingress ingress` to find the allocation for

--- a/acls/api-gateway.policy.hcl
+++ b/acls/api-gateway.policy.hcl
@@ -1,36 +1,18 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-acl = "write"
 
-agent_prefix "" {
-  policy = "write"
-}
-
-event_prefix "" {
-  policy = "write"
-}
-
-identity_prefix "" {
-  policy     = "write"
-  intentions = "write"
-}
-
-key_prefix "" {
-  policy = "write"
-}
+mesh = "read"
 
 node_prefix "" {
-  policy = "write"
-}
-
-mesh = "write"
-
-query_prefix "" {
-  policy = "write"
+  policy = "read"
 }
 
 service_prefix "" {
-  policy     = "write"
-  intentions = "write"
+  policy = "read"
+}
+
+# Change the API Gateway service name here if you are overriding 'var.api_gateway_name'
+service "my-api-gateway" {
+  policy = "write"
 }

--- a/example/hello-app-service-defaults.hcl
+++ b/example/hello-app-service-defaults.hcl
@@ -1,0 +1,4 @@
+Kind     = "service-defaults"
+Name     = "hello-app"
+protocol = "http"
+


### PR DESCRIPTION
* Tweak the policy to only have the least minimal rules required for API Gateway
* Add service defaults to set the service type to `http`.

Without the service defaults, the API Gw listener won't populate as the `http-route` won't be accepted due to service protocol mismatch and throws the following error when we read the `http-route` config entry.

```
...
"Status": {
    "Conditions": [
        {
            "Type": "Accepted",
            "Status": "False",
            "Reason": "InvalidDiscoveryChain",
            "Message": "route protocol does not match targeted service protocol",
            "Resource": {
                "Kind": "",
                "Name": "",
                "SectionName": ""
            },
            "LastTransitionTime": "2024-07-04T00:23:16.080657687Z"
        },
        {
            "Type": "Bound",
            "Status": "False",
            "Reason": "FailedToBind",
            "Message": "failed to bind route to gateway my-api-gateway: route has not been accepted",
            "Resource": {
                "Kind": "api-gateway",
                "Name": "my-api-gateway",
                "SectionName": "my-http-listener"
            },
            "LastTransitionTime": "2024-07-04T00:23:16.080672646Z"
        }
    ]
}
...
```